### PR TITLE
Last Minute Fixes.

### DIFF
--- a/lua/modules/alpha_halo/systems/firefightManager.lua
+++ b/lua/modules/alpha_halo/systems/firefightManager.lua
@@ -49,6 +49,7 @@ firefightManager.firefightSettings = {
     -- Game settings
     startingEnemyTeam = 1, -- 1 = Covenant, 2 = Flood, 3 = Random
     permanentSkullsCanBeRandom = true,
+    roundEndingBoss = true,
     -- Event properties
     activateTemporalSkullEach = eventNames.eachRound,
     activatePermanentSkullEach = eventNames.eachSet
@@ -188,9 +189,10 @@ end
 --- Define in which type of wave are we depending on the settings.
 function firefightManager.waveDefinition()
     isFirstRoundWave = progression.wave == 1
-    isCurrentWaveBoss = (progression.wave == settings.wavesPerRound) or
-                            (settings.bossWaveFrequency > 0 and
-                                math.fmod(progression.wave, settings.bossWaveFrequency) == 0)
+    isCurrentWaveBoss = ((settings.roundEndingBoss == true) and
+                        (progression.wave == settings.wavesPerRound)) or
+                        (settings.bossWaveFrequency > 0 and
+                        math.fmod(progression.totalWaves, settings.bossWaveFrequency) == 0)
     isFirstGameWave = (progression.wave == 1) and (progression.round == 1) and
                           (progression.set == 1) -- progression.totalWaves == 1 (for unknown reasons, using totalWaves don't work)
     isLastWave = (progression.wave == settings.wavesPerRound) and
@@ -290,7 +292,7 @@ function firefightManager.playerCheck(call, sleep)
         logger:debug("Player is dead.")
         playerIsDead = true
         -- If lifes are 0 and there's no player biped, then we end the game.
-        if playerLives == 0 then
+        if playerLives <= 0 then
             logger:info("You lost, sucker!!!")
             firefightManager.endGame()
         end


### PR DESCRIPTION
Added support for deactivating the mandatory boss wave at the end of each round. This comes as an extra boolean in settings and an aditional condition in waveDefinition.

Also switched the bossFrequency to work with .totalWaves instead of .waves, to avoid confusion among players due to the restoring nature of .waves. This avoids us the necessity of finding a way to cap bossWaveFrequency, and also gives the player more freedom to customize their experience.

Finally, fixed bug where game didn't end if player's life were bellow 0. Just changed the end_game being triggered by == 0 lifes remaining to <= 0.

There's still a lingering problem regarding waveLivingMin and bossWaveLivingMin not actually working, and some settings values on Insurrection menu are not within the appropiate range.