### PR TITLE
New events and deployer allies fix

### DIFF
--- a/lua/modules/alpha_halo/systems/firefight/unitDeployer.lua
+++ b/lua/modules/alpha_halo/systems/firefight/unitDeployer.lua
@@ -231,23 +231,26 @@ local odstSquadName = "Human_Team/ODSTs"
 function unitDeployer.scriptDeployPelicans(call, sleep)
     sleep(constants.pelicanDeploymentDelay)
     hsc.ai_place(odstSquadName)
-    hsc.ai_place(pelicanPilotName)
+    -- TODO Make a custom biped for the Pelican turrets that can attack while in the Pelican.
+    --hsc.ai_place(pelicanPilotName)
     -- TODO Prevent ODSTs from receiving damage while in the Pelican.
     hsc.object_create_anew(pelicanVehicleName)
     hsc.vehicle_load_magic(pelicanVehicleName, "rider", hsc.ai_actors(odstSquadName))
-    hsc.vehicle_load_magic(pelicanVehicleName, "driver", hsc.ai_actors(pelicanPilotName))
+    --hsc.vehicle_load_magic(pelicanVehicleName, "driver", hsc.ai_actors(pelicanPilotName))
+    hsc.ai_migrate(odstSquadName, "standby_pelican") -- No jala
     -- TODO This should be a dynamic encounter based on the current wave.
     -- Otherwise it just forces the AI to only see Covenant
-    hsc.ai_magically_see_encounter("human_support", "Covenant_Wave")
+    --hsc.ai_magically_see_encounter("human_support", "Covenant_Wave")
     hsc.unit_set_enterable_by_player(pelicanVehicleName, false)
     hsc.unit_close(pelicanVehicleName)
     hsc.object_teleport(pelicanVehicleName, "foehammer_cliff_flag")
-    hsc.ai_braindead_by_unit(hsc.ai_actors("Human_Team"), true)
+    hsc.ai_braindead_by_unit(hsc.ai_actors("standby_pelican"), true)
     hsc.recording_play_and_hover(pelicanVehicleName, "foehammer_cliff_in")
     sleep(1200)
     hsc.unit_open(pelicanVehicleName)
-    sleep(90)
-    hsc.ai_braindead_by_unit(hsc.ai_actors("Human_Team"), false)
+    sleep(70)
+    hsc.ai_braindead_by_unit(hsc.ai_actors("standby_pelican"), false)
+    hsc.ai_migrate("standby_pelican", odstSquadName)
     hsc.vehicle_unload(pelicanVehicleName, "rider")
     sleep(120)
     if not hsc.vehicle_test_seat_list(pelicanVehicleName, "rider", hsc.ai_actors(odstSquadName)) then

--- a/lua/modules/alpha_halo/systems/firefight/unitDeployer.lua
+++ b/lua/modules/alpha_halo/systems/firefight/unitDeployer.lua
@@ -226,6 +226,7 @@ end
 local pelicanVehicleName = "foehammer_cliff"
 local pelicanPilotName = "human_support/pelican_pilot"
 local odstSquadName = "Human_Team/ODSTs"
+local odstPelicanSquad = "standby_pelican"
 
 -- Deploy allied ODSTs in a Pelican.
 function unitDeployer.scriptDeployPelicans(call, sleep)
@@ -237,20 +238,20 @@ function unitDeployer.scriptDeployPelicans(call, sleep)
     hsc.object_create_anew(pelicanVehicleName)
     hsc.vehicle_load_magic(pelicanVehicleName, "rider", hsc.ai_actors(odstSquadName))
     --hsc.vehicle_load_magic(pelicanVehicleName, "driver", hsc.ai_actors(pelicanPilotName))
-    hsc.ai_migrate(odstSquadName, "standby_pelican") -- No jala
+    hsc.ai_migrate(odstSquadName, odstPelicanSquad)
     -- TODO This should be a dynamic encounter based on the current wave.
     -- Otherwise it just forces the AI to only see Covenant
     --hsc.ai_magically_see_encounter("human_support", "Covenant_Wave")
     hsc.unit_set_enterable_by_player(pelicanVehicleName, false)
     hsc.unit_close(pelicanVehicleName)
     hsc.object_teleport(pelicanVehicleName, "foehammer_cliff_flag")
-    hsc.ai_braindead_by_unit(hsc.ai_actors("standby_pelican"), true)
+    hsc.ai_braindead_by_unit(hsc.ai_actors(odstPelicanSquad), true)
     hsc.recording_play_and_hover(pelicanVehicleName, "foehammer_cliff_in")
     sleep(1200)
     hsc.unit_open(pelicanVehicleName)
     sleep(70)
-    hsc.ai_braindead_by_unit(hsc.ai_actors("standby_pelican"), false)
-    hsc.ai_migrate("standby_pelican", odstSquadName)
+    hsc.ai_braindead_by_unit(hsc.ai_actors(odstPelicanSquad), false)
+    hsc.ai_migrate(odstPelicanSquad, odstSquadName)
     hsc.vehicle_unload(pelicanVehicleName, "rider")
     sleep(120)
     if not hsc.vehicle_test_seat_list(pelicanVehicleName, "rider", hsc.ai_actors(odstSquadName)) then

--- a/lua/modules/alpha_halo/systems/firefightManager.lua
+++ b/lua/modules/alpha_halo/systems/firefightManager.lua
@@ -754,6 +754,8 @@ function firefightManager.loadSettings()
             -- Load events properties
             loadEvent(firefightManager.enableTemporalSkull, settings.activateTemporalSkullEach)
             loadEvent(firefightManager.enablePermanentSkull, settings.activatePermanentSkullEach)
+            loadEvent(firefightManager.conditionedResetAllTemporalSkulls, settings.resetTemporalSkullEach)
+            loadEvent(firefightManager.deployPlayerAllies, settings.deployAlliesEach)
             logger:info("Firefight settings loaded from file.")
             return
         end


### PR DESCRIPTION
Add new settings for events like **reset temporal skulls** and **deploy allies**. 
Fix braindead ODST in battlefield when deploy another ODST squad 