### PR TITLE
Add skulls multiplier text HUD

### DIFF
--- a/lua/modules/alpha_halo/main.lua
+++ b/lua/modules/alpha_halo/main.lua
@@ -68,7 +68,10 @@ Balltze.event.frame.subscribe(function(event)
         if isPlayerOnMenu then
             return
         end
-
+        local player = get_dynamic_player()
+        if not player then
+            return
+        end
         firefightManager.onEachFrame()
     end
 end)

--- a/lua/modules/alpha_halo/systems/core/constants.lua
+++ b/lua/modules/alpha_halo/systems/core/constants.lua
@@ -47,6 +47,9 @@ function constants.get()
 
     constants.fonts = {
         title = findTags("geogrotesque-regular-title", engine.tag.classes.font)[1],
+        subtitle = findTags("geogrotesque-regular-subtitle", engine.tag.classes.font)[1],
+        text = findTags("geogrotesque-regular-text", engine.tag.classes.font)[1],
+        smaller = findTags("geogrotesque-regular-smaller", engine.tag.classes.font)[1]
     }
 
     constants.hud = {

--- a/lua/modules/alpha_halo/systems/firefightManager.lua
+++ b/lua/modules/alpha_halo/systems/firefightManager.lua
@@ -490,8 +490,9 @@ function firefightManager.updateSkullsHud()
                                    firefightManager.prevSkullStates or {}
     firefightManager.skullInfoTimers, firefightManager.prevSkullStates = timers, prevSkullState
 
-    local hudColor, infoColor, emptyColor = {255, 125, 238, 85}, -- Alpha, Red, Green, Blue
-    {255, 255, 187, 0}, {0, 0, 0, 0}
+    local hudColor = {255, 125, 238, 85} -- Alpha, Red, Green, Blue
+    local infoColor = {255, 255, 187, 0}
+    local emptyColor = {0, 0, 0, 0}
 
     local function setElementColor(element, color)
         local channels = {"alpha", "red", "green", "blue"}
@@ -772,7 +773,9 @@ end
 function firefightManager.onEachFrame()
     local drawText = balltze.chimera.draw_text
     local titleText = const.fonts.title.handle.value
+    local standardText = const.fonts.text.handle.value
     local textColorW = {1.0, 1.0, 1.0, 1.0}
+    local infoColor = {255 / 255, 255 / 255, 187 / 255, 0 / 255}
     -- Show current game progression info
     local text = ("Set: {set} Round: {round} Wave: {wave}"):template(
                      firefightManager.gameProgression)
@@ -789,18 +792,19 @@ function firefightManager.onEachFrame()
 
         for i = 1, hudIcons.staticElements.count do
             -- Toma el cráneo en la misma posición del HUD, no invertido
-            local skullObj = skullsManager.enabledSkullsQueue[i]
+            local skullObj = skullsManager.enabledSkullsQueue[#skullsManager.enabledSkullsQueue - (i - 1)]
             local skullElement = hudIcons.staticElements.elements[i]
 
             if skullObj and skullObj.isEnabled then
                 local skullName = table.keyof(skullsManager.skulls, skullObj)
                 if skullName then
-                    local multiplier = skullsManager.skulls[skullName].state.multiplier
-                    if multiplier > 1 then
-                        local y = skullElement.anchorOffset.y
-                        local multText = "x" .. tostring(multiplier)
-                        drawText(multText, bounds.left, y + 193, bounds.right + 5, bounds.bottom, titleText,
-                        align, table.unpack(textColorW))
+                    local count = skullsManager.skulls[skullName].state.count or 1
+                    if count >= 1 then
+                        --local y = bounds.top - 40 - (i - 1) * 40
+                        local y = bounds.top - skullElement.anchorOffset.y + 80
+                        local multText = "x" .. tostring(count)
+                        drawText(multText, bounds.left, y, bounds.right + 5, bounds.bottom, standardText,
+                        align, table.unpack(infoColor))
                     end
                 end
             end

--- a/lua/modules/alpha_halo/systems/firefightManager.lua
+++ b/lua/modules/alpha_halo/systems/firefightManager.lua
@@ -527,6 +527,8 @@ function firefightManager.updateSkullsHud()
             skullsManager.enabledSkullsQueue[#skullsManager.enabledSkullsQueue - (i - 1)]
         local skullIconElement = hudIcons.staticElements.elements[i]
         if currentSkullIcon and currentSkullIcon.isEnabled then
+            -- local skullElement = hudIcons.anchor
+            -- logger:debug("Anchor: {}", skullElement)
             local skullName = table.keyof(skullsManager.skulls, currentSkullIcon)
             skullIconElement.sequenceIndex =
                 (table.indexof(skullsManager.skullsHudOrder, skullName) or 1) - 1
@@ -766,18 +768,44 @@ function firefightManager.loadSettings()
     return
 end
 
+
 function firefightManager.onEachFrame()
+    local drawText = balltze.chimera.draw_text
+    local titleText = const.fonts.title.handle.value
+    local textColorW = {1.0, 1.0, 1.0, 1.0}
     -- Show current game progression info
     local text = ("Set: {set} Round: {round} Wave: {wave}"):template(
                      firefightManager.gameProgression)
 
-    balltze.chimera.draw_text(text, bounds.left, bounds.top, bounds.right, bounds.bottom,
-                              const.fonts.title.handle.value, align, table.unpack(textColor))
+    drawText(text, bounds.left, bounds.top, bounds.right, bounds.bottom, titleText, align,table.unpack(textColor))
 
     -- Draw current lifes
     local livesText = ("Lives: {lives}"):template({lives = playerLives or 0})
-    balltze.chimera.draw_text(livesText, bounds.left, bounds.top - 20, bounds.right, bounds.bottom,
-                              const.fonts.title.handle.value, align, table.unpack(textColor))
+    drawText(livesText, bounds.left, bounds.top - 20, bounds.right, bounds.bottom, titleText, align, table.unpack(textColor))
+
+    -- Multipliers per Skull
+    if const.hud.skullsIcons then
+        local hudIcons = const.hud.skullsIcons.data
+
+        for i = 1, hudIcons.staticElements.count do
+            -- Toma el cráneo en la misma posición del HUD, no invertido
+            local skullObj = skullsManager.enabledSkullsQueue[i]
+            local skullElement = hudIcons.staticElements.elements[i]
+
+            if skullObj and skullObj.isEnabled then
+                local skullName = table.keyof(skullsManager.skulls, skullObj)
+                if skullName then
+                    local multiplier = skullsManager.skulls[skullName].state.multiplier
+                    if multiplier > 1 then
+                        local y = skullElement.anchorOffset.y
+                        local multText = "x" .. tostring(multiplier)
+                        drawText(multText, bounds.left, y + 193, bounds.right + 5, bounds.bottom, titleText,
+                        align, table.unpack(textColorW))
+                    end
+                end
+            end
+        end
+    end
 end
 
 return firefightManager

--- a/lua/modules/alpha_halo/systems/firefightManager.lua
+++ b/lua/modules/alpha_halo/systems/firefightManager.lua
@@ -776,31 +776,31 @@ function firefightManager.onEachFrame()
     local standardText = const.fonts.text.handle.value
     local textColorW = {1.0, 1.0, 1.0, 1.0}
     local infoColor = {255 / 255, 255 / 255, 187 / 255, 0 / 255}
+
     -- Show current game progression info
     local text = ("Set: {set} Round: {round} Wave: {wave}"):template(
                      firefightManager.gameProgression)
-
     drawText(text, bounds.left, bounds.top, bounds.right, bounds.bottom, titleText, align,table.unpack(textColor))
 
     -- Draw current lifes
     local livesText = ("Lives: {lives}"):template({lives = playerLives or 0})
     drawText(livesText, bounds.left, bounds.top - 20, bounds.right, bounds.bottom, titleText, align, table.unpack(textColor))
 
-    -- Multipliers per Skull
+    -- Draw the number of times each skull was activated
     if const.hud.skullsIcons then
         local hudIcons = const.hud.skullsIcons.data
 
         for i = 1, hudIcons.staticElements.count do
-            -- Toma el cráneo en la misma posición del HUD, no invertido
             local skullObj = skullsManager.enabledSkullsQueue[#skullsManager.enabledSkullsQueue - (i - 1)]
             local skullElement = hudIcons.staticElements.elements[i]
 
             if skullObj and skullObj.isEnabled then
                 local skullName = table.keyof(skullsManager.skulls, skullObj)
+
                 if skullName then
                     local count = skullsManager.skulls[skullName].state.count or 1
+
                     if count >= 1 then
-                        --local y = bounds.top - 40 - (i - 1) * 40
                         local y = bounds.top - skullElement.anchorOffset.y + 80
                         local multText = "x" .. tostring(count)
                         drawText(multText, bounds.left, y, bounds.right + 5, bounds.bottom, standardText,

--- a/lua/modules/alpha_halo/systems/gameplay/skullsManager.lua
+++ b/lua/modules/alpha_halo/systems/gameplay/skullsManager.lua
@@ -134,7 +134,7 @@ skullsManager.skulls = {
         motto = "Deliver hope... and tactical warheads.",
         description = "Doubles explosions radius effect.",
         effect = havok.skullEffect,
-        state = {count = 0, max = 2, multiplier = 1},
+        state = {count = 0, max = 2, multiplier = 3},
         allowedInRandom = true,
         enabledFromTheStart = true,
         isEnabled = false,
@@ -145,7 +145,7 @@ skullsManager.skulls = {
         motto = "That is... not how the 3rd law works.",
         description = "Melee hits now inflict knockback... To both ends.",
         effect = newton.skullEffect,
-        state = {count = 0, max = 2, multiplier = 1},
+        state = {count = 0, max = 2, multiplier = 4},
         allowedInRandom = true,
         enabledFromTheStart = true,
         isEnabled = false,
@@ -166,7 +166,7 @@ skullsManager.skulls = {
         motto = "Send me out, with a bang.",
         description = "Some enemies drop live grenades at death.",
         effect = banger.skullEffect,
-        state = {count = 0, max = 1, multiplier = 1},
+        state = {count = 0, max = 1, multiplier = 5},
         allowedInRandom = true,
         isEnabled = false,
         isPermanent = false
@@ -176,7 +176,7 @@ skullsManager.skulls = {
         motto = "Do I feel lucky?",
         description = "Doubles your shield... As well as the stun and recovering time.",
         effect = doubleDown.skullEffect,
-        state = {count = 0, max = 2, multiplier = 1},
+        state = {count = 0, max = 2, multiplier = 4},
         allowedInRandom = true,
         isEnabled = false,
         isPermanent = false
@@ -196,7 +196,7 @@ skullsManager.skulls = {
         motto = "A change of pace.",
         description = "Full auto weapons become semi-auto and vice versa.",
         effect = triggerSwitch.skullEffect,
-        state = {count = 0, max = 1, multiplier = 1},
+        state = {count = 0, max = 1, multiplier = 3},
         allowedInRandom = true,
         isEnabled = false,
         isPermanent = false
@@ -206,7 +206,7 @@ skullsManager.skulls = {
         motto = "Double every shot by sheer will of rip and tear.",
         description = "Doubles projectiles per shot and spread cone size.",
         effect = slayer.skullEffect,
-        state = {count = 0, max = 2, multiplier = 1},
+        state = {count = 0, max = 1, multiplier = 2},
         allowedInRandom = true,
         isEnabled = false,
         isPermanent = false
@@ -226,24 +226,24 @@ skullsManager.skulls = {
 }
 
 local skullList = {
-    skullsManager.skulls.famine,
-    skullsManager.skulls.mythic,
-    -- skullsManager.skulls.blind,
-    -- skullsManager.skulls.catch,
-    skullsManager.skulls.berserk,
-    skullsManager.skulls.toughluck,
-    -- skullsManager.skulls.fog,
-    skullsManager.skulls.knucklehead,
-    skullsManager.skulls.cowbell,
+    --skullsManager.skulls.famine,
+    --skullsManager.skulls.mythic,
+    ---- skullsManager.skulls.blind,
+    ---- skullsManager.skulls.catch,
+    --skullsManager.skulls.berserk,
+    --skullsManager.skulls.toughluck,
+    ---- skullsManager.skulls.fog,
+    --skullsManager.skulls.knucklehead,
+    --skullsManager.skulls.cowbell,
     skullsManager.skulls.havok,
     skullsManager.skulls.newton,
-    skullsManager.skulls.tilt,
+    --skullsManager.skulls.tilt,
     skullsManager.skulls.banger,
     skullsManager.skulls.doubledown,
-    skullsManager.skulls.eyepatch,
+    --skullsManager.skulls.eyepatch,
     skullsManager.skulls.triggerswitch,
     skullsManager.skulls.slayer
-    -- skullsManager.skulls.assassin
+    ---- skullsManager.skulls.assassin
 }
 skullsManager.skullList = skullList
 

--- a/lua/modules/alpha_halo/systems/gameplay/skullsManager.lua
+++ b/lua/modules/alpha_halo/systems/gameplay/skullsManager.lua
@@ -134,7 +134,7 @@ skullsManager.skulls = {
         motto = "Deliver hope... and tactical warheads.",
         description = "Doubles explosions radius effect.",
         effect = havok.skullEffect,
-        state = {count = 0, max = 2, multiplier = 3},
+        state = {count = 0, max = 2, multiplier = 1},
         allowedInRandom = true,
         enabledFromTheStart = true,
         isEnabled = false,
@@ -145,7 +145,7 @@ skullsManager.skulls = {
         motto = "That is... not how the 3rd law works.",
         description = "Melee hits now inflict knockback... To both ends.",
         effect = newton.skullEffect,
-        state = {count = 0, max = 2, multiplier = 4},
+        state = {count = 0, max = 2, multiplier = 1},
         allowedInRandom = true,
         enabledFromTheStart = true,
         isEnabled = false,
@@ -166,7 +166,7 @@ skullsManager.skulls = {
         motto = "Send me out, with a bang.",
         description = "Some enemies drop live grenades at death.",
         effect = banger.skullEffect,
-        state = {count = 0, max = 1, multiplier = 5},
+        state = {count = 0, max = 1, multiplier = 1},
         allowedInRandom = true,
         isEnabled = false,
         isPermanent = false
@@ -176,7 +176,7 @@ skullsManager.skulls = {
         motto = "Do I feel lucky?",
         description = "Doubles your shield... As well as the stun and recovering time.",
         effect = doubleDown.skullEffect,
-        state = {count = 0, max = 2, multiplier = 4},
+        state = {count = 0, max = 2, multiplier = 1},
         allowedInRandom = true,
         isEnabled = false,
         isPermanent = false
@@ -196,7 +196,7 @@ skullsManager.skulls = {
         motto = "A change of pace.",
         description = "Full auto weapons become semi-auto and vice versa.",
         effect = triggerSwitch.skullEffect,
-        state = {count = 0, max = 1, multiplier = 3},
+        state = {count = 0, max = 1, multiplier = 1},
         allowedInRandom = true,
         isEnabled = false,
         isPermanent = false
@@ -206,7 +206,7 @@ skullsManager.skulls = {
         motto = "Double every shot by sheer will of rip and tear.",
         description = "Doubles projectiles per shot and spread cone size.",
         effect = slayer.skullEffect,
-        state = {count = 0, max = 1, multiplier = 2},
+        state = {count = 0, max = 1, multiplier = 1},
         allowedInRandom = true,
         isEnabled = false,
         isPermanent = false
@@ -226,24 +226,24 @@ skullsManager.skulls = {
 }
 
 local skullList = {
-    --skullsManager.skulls.famine,
-    --skullsManager.skulls.mythic,
-    ---- skullsManager.skulls.blind,
-    ---- skullsManager.skulls.catch,
-    --skullsManager.skulls.berserk,
-    --skullsManager.skulls.toughluck,
-    ---- skullsManager.skulls.fog,
-    --skullsManager.skulls.knucklehead,
-    --skullsManager.skulls.cowbell,
+    skullsManager.skulls.famine,
+    skullsManager.skulls.mythic,
+    -- skullsManager.skulls.blind,
+    -- skullsManager.skulls.catch,
+    skullsManager.skulls.berserk,
+    skullsManager.skulls.toughluck,
+    -- skullsManager.skulls.fog,
+    skullsManager.skulls.knucklehead,
+    skullsManager.skulls.cowbell,
     skullsManager.skulls.havok,
     skullsManager.skulls.newton,
-    --skullsManager.skulls.tilt,
+    skullsManager.skulls.tilt,
     skullsManager.skulls.banger,
     skullsManager.skulls.doubledown,
-    --skullsManager.skulls.eyepatch,
+    skullsManager.skulls.eyepatch,
     skullsManager.skulls.triggerswitch,
-    skullsManager.skulls.slayer
-    ---- skullsManager.skulls.assassin
+    skullsManager.skulls.slayer,
+    -- skullsManager.skulls.assassin
 }
 skullsManager.skullList = skullList
 


### PR DESCRIPTION
# Skulls Multiplier Draw Text
Attempt to implement a draw_text for the skull multiplier. 
After activating more than 2 skulls, the text begins to draw downward.

## Example 1
_In this SS, I activate 2 skulls with hardcoded multipliers (**Double Down** `X4 `and **Havok** `X3`), and it looks good._
<img width="639" height="513" alt="sample_1" src="https://github.com/user-attachments/assets/e3c7b2f8-acef-441d-a99d-662d6775be3b" />

## Example 2
_When I activate another one, the text draws downward (**Slayer** `X2` should take the first position)._
<img width="639" height="513" alt="sample_2" src="https://github.com/user-attachments/assets/c611d8e1-1ce7-4656-9e77-8978d50e7e8d" />
